### PR TITLE
Add DefinitionProvider to allow modules to provide definitions

### DIFF
--- a/src/DefinitionProvider.php
+++ b/src/DefinitionProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Interop\Container\Definition;
+
+/**
+ * A module can implement that interface to register container entries by providing definitions.
+ */
+interface DefinitionProvider
+{
+    /**
+     * Returns the definition to register in the container.
+     *
+     * @return DefinitionInterface[]
+     */
+    public function getDefinitions();
+}

--- a/src/DefinitionProviderInterface.php
+++ b/src/DefinitionProviderInterface.php
@@ -5,7 +5,7 @@ namespace Interop\Container\Definition;
 /**
  * A module can implement that interface to register container entries by providing definitions.
  */
-interface DefinitionProvider
+interface DefinitionProviderInterface
 {
     /**
      * Returns the definition to register in the container.


### PR DESCRIPTION
Modules need to be able to expose definitions to the framework (or module system) that is consuming them. To do that, they can implement this interface to return definitions to register.

I don't remember what was the conclusion today but after thinking about it more I think we have to have this interface. Even if using Puli or something in the `extra` section in `composer.json`, we need to have this class (definitions can't come out of nowhere).

Example:

``` php
namespace MyModule;

class DefinitionProvider implements Interop\Container\Definition\DefinitionProvider
{
    public function getDefinitions()
    {
        return [ ... ];
    }
}
```
