### PR TITLE
Improve the readme to explain the goal of the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 # Container Definitions Interoperability
 
-*definition-interop* tries to identify and standardize features in *container definitions* to achieve
-interoperability.
+*definition-interop* tries to offer a solution for writing **cross-framework modules**.
 
-While *container-interop/container-interop* tries to standardize how we fetch entries from containers,
-*container-interop/definition-interop* tries to standardize how to describe container entries.
+## Introduction
 
-The work done in this project is not officially endorsed by the [PHP-FIG](http://www.php-fig.org/), but it is being
-worked on by members of PHP-FIG and other good developers. We adhere to the spirit and ideals of PHP-FIG, and hope
-this project will pave the$ way for one or more future PSRs.
+Modules (aka packages or bundles) are widespread in modern frameworks. Unfortunately each framework has its own convention and tools for writing them. The goal of *container-interop* and more specifically *definition-interop* is to help developers write modules that can work in any framework.
 
+Cross-framework modules can take advantage of PSR-7 (HTTP requests and responses abstractions) as well as Puli (resource location in packages), but the last missing piece is letting modules register container entries. That is necessary so that modules can expose services to users.
+
+## Scope
+
+While *container-interop/container-interop* tries to standardize how to fetch entries from containers, *container-interop/definition-interop* tries to standardize how to define container entries.
+
+The definitions standardized in this package *are only meant to be used by modules*; they are not meant to cover every use case of every container. Given this restricted scope, the definitions are intentionally simple in order to be easily supported by every container.
+
+With that in mind, users can rest assured that they can use all the features offered by their container of choice, while only module developers have to make use of the standard definitions.
 
 ## Installation
-
-You can install this package through Composer:
 
 ```
 composer require container-interop/definition-interop@dev
 ```
 
-The packages adheres to the [SemVer](http://semver.org/) specification, and there will be full backward compatibility
-between minor versions.
+This package adheres to the [SemVer](http://semver.org/) specification and will be fully backward compatible between minor versions.


### PR DESCRIPTION
This is an attempt at explaining a bit more in the README what we discussed those last 2 days with @moufmouf and other FIG members at ForumPHP.

In the future all that explanation might go in a separate document, but in the meantime I think it's good to have it in the readme.

@Ocramius (which might have seen this repo since you're a member of the org) and to anyone else reading: I hope this PR explains a little bit this new repo that has popped up today. What came out of those discussions was that we should try an approach based on the following observations:
- standardizing container configuration/definitions is hard because there are a million different features
- containers will not restrict their features to match a standard
- the goal is to have cross-framework modules, so the only thing needed is to have containers be able to consume those modules
- most modules have limited needs in terms of features: they can expose container configuration with limited syntax/options
- some modules will have to be framework specific, especially big, complex and very specific modules: we can't do anything about them, let's focus on the 90% modules we can address

With that in mind we want to try an approach with standard definitions that would only be used by modules (because they are pretty basic). We want to see if those basic definitions can be enough to cover most use cases. In a first step, we'll leave aside definitions that extend other definitions (that include decorators, tags, collections/arrays, …). This is absolutely WIP.
