### PR TITLE
Adding arguments to the factory

### DIFF
--- a/src/FactoryDefinitionInterface.php
+++ b/src/FactoryDefinitionInterface.php
@@ -28,4 +28,11 @@ interface FactoryDefinitionInterface extends DefinitionInterface
      * @return string
      */
     public function getMethodName();
+
+    /**
+     * Returns the list of arguments to pass when calling the method.
+     *
+     * @return array Array of scalars or ReferenceInterface.
+     */
+    public function getArguments();
 }


### PR DESCRIPTION
A factory method should be allowed to have arguments, as most existing factory can take parameters.
