### PR TITLE
Stricter DefinitionProviderInterface::getDefinitions() return type

### DIFF
--- a/src/DefinitionProviderInterface.php
+++ b/src/DefinitionProviderInterface.php
@@ -17,7 +17,7 @@ interface DefinitionProviderInterface
      *         'mailer' => ...
      *     ];
      *
-     * @return array
+     * @return DefinitionInterface[]
      */
     public function getDefinitions();
 }

--- a/src/DefinitionProviderInterface.php
+++ b/src/DefinitionProviderInterface.php
@@ -17,6 +17,13 @@ interface DefinitionProviderInterface
      *         'mailer' => ...
      *     ];
      *
+     * Definitions MUST be objects implementing one of those interfaces:
+     *
+     * - `ObjectDefinitionInterface`
+     * - `FactoryCallDefinitionInterface`
+     * - `ParameterDefinitionInterface`
+     * - `ReferenceDefinitionInterface`
+     *
      * @return DefinitionInterface[]
      */
     public function getDefinitions();


### PR DESCRIPTION
References #22 

Enforce that `DefinitionProviderInterface::getDefinitions()` returns an array of `DefinitionInterface`.
